### PR TITLE
you have no students message only displays for current teacher's profile

### DIFF
--- a/app/views/teachers/show.html.erb
+++ b/app/views/teachers/show.html.erb
@@ -5,7 +5,7 @@
     <%= link_to "Edit Profile", edit_teacher_path, class: "button" %><br><br>
   <% end %>
 
-  <% if @teacher.students.length == 0 %>
+  <% if @teacher == current_teacher && @teacher.students.length == 0 %>
     <div>
       <p>Welcome, <%= @teacher.name %>!  You currently have no students.</p>
       <p>Click <%= link_to 'here', students_path %> to start adding students.</p>


### PR DESCRIPTION
Quick minor fix: if teacher A is looking at teacher B's profile, and teacher B has no students, then it no longer says to A "Welcome B, you have no students, click here to add some."  Instead it just displays the empty table to show that B has no students.
